### PR TITLE
fix: synchronize imported metadata with oscilloscope and function generator behavior

### DIFF
--- a/src/LAB/LAB_Oscilloscope.cpp
+++ b/src/LAB/LAB_Oscilloscope.cpp
@@ -1796,6 +1796,14 @@ double LAB_Oscilloscope::
   return (m_parent_data.sampling_rate_raw_buffer);
 }
 
+void LAB_Oscilloscope::
+    sync_display_metadata_from_current_settings()
+{
+  m_parent_data.horizontal_offset_raw_buffer = m_parent_data.horizontal_offset;
+  m_parent_data.time_per_division_raw_buffer = m_parent_data.time_per_division;
+  m_parent_data.sampling_rate_raw_buffer     = m_parent_data.sampling_rate;
+}
+
 // LAB_Oscilloscope::Measurements
 
 LAB_Oscilloscope::Measurements::

--- a/src/LAB/LAB_Oscilloscope.h
+++ b/src/LAB/LAB_Oscilloscope.h
@@ -14,7 +14,7 @@ class LAB_Oscilloscope : public LAB_Module
     {
       private:
         LAB_Parent_Data_Oscilloscope& m_pdata;
-      
+
       public:
         Calibration (LAB_Parent_Data_Oscilloscope& _LAB_Parent_Data_Oscilloscope);
 
@@ -24,7 +24,7 @@ class LAB_Oscilloscope : public LAB_Module
 
         bool    do_auto_calibration_vertical_offset_corrector ();
         bool    do_auto_calibration_scaling_correctors        ();
-        
+
         void    adc_reference_voltage       (unsigned channel, double value);
         void    vertical_offset_corrector   (unsigned channel, LABE::OSC::SCALING scaling, double value);
         void    scaling_corrector_to_unity  (unsigned channel, LABE::OSC::SCALING scaling, double value);
@@ -40,7 +40,7 @@ class LAB_Oscilloscope : public LAB_Module
     {
       private:
         LAB_Parent_Data_Oscilloscope& m_pdata;
-      
+
       public:
         Measurements (LAB_Parent_Data_Oscilloscope& _LAB_Parent_Data_Oscilloscope);
 
@@ -49,12 +49,12 @@ class LAB_Oscilloscope : public LAB_Module
         double min  (unsigned chan);
         double trms (unsigned chan);
     };
-  
+
   private:
     std::thread                   m_thread_trigger;
     std::thread                   m_find_trigger_timer;
-    AikaPi::Uncached              m_uncached_memory;   
-    LAB_Parent_Data_Oscilloscope  m_parent_data; 
+    AikaPi::Uncached              m_uncached_memory;
+    LAB_Parent_Data_Oscilloscope  m_parent_data;
     Measurements                  m_measurements;
     Calibration                   m_calibration;
 
@@ -70,25 +70,25 @@ class LAB_Oscilloscope : public LAB_Module
     // Master Controls
     void                master_run_stop                 (bool value);
 
-    // State 
+    // State
     void                status                          (LABE::OSC::STATUS _STATUS);
     void                reload_settings                 ();
 
     // Mode
     void                set_mode                        (LABE::OSC::MODE mode);
     void                dma_buffer_count                (LABE::OSC::BUFFER_COUNT buffer_count);
-  
-    // Horizontal 
+
+    // Horizontal
     double              calc_time_per_division          (unsigned samples, double sampling_rate)          const;
     double              calc_sampling_rate              (unsigned samples, double time_per_division)      const;
     void                set_time_per_division           (double value);
     void                set_samples                     (unsigned value);
     void                set_sampling_rate               (double value);
-    
+
     // mode
-    LABE::OSC::MODE     calc_mode                       (double time_per_division);    
-  
-    // trigger 
+    LABE::OSC::MODE     calc_mode                       (double time_per_division);
+
+    // trigger
     void                parse_trigger_mode              ();
     void                trigger_osc_mode_dispatcher     ();
     void                trigger_osc_mode_repeated       ();
@@ -111,16 +111,16 @@ class LAB_Oscilloscope : public LAB_Module
     void                fill_raw_osc_samp_buff_from_dma_buff   ();
     void                parse_raw_osc_samp_buff                ();
 
-     double    
+     double
     conv_raw_osc_samp_to_actual_chan_value      (uint32_t raw_osc_samp,       unsigned channel);
 
-     uint32_t  
+     uint32_t
     extract_raw_osc_chan_samp_from_raw_osc_samp (uint32_t raw_osc_samp,       unsigned channel);
 
-     uint32_t  
+     uint32_t
     reconstruct_adc_data_from_raw_osc_chan_samp (uint32_t raw_osc_chan_samp,  unsigned channel);
 
-     uint32_t  
+     uint32_t
     reconstruct_raw_osc_chan_samp_from_adc_data (uint32_t adc_data);
 
      double
@@ -128,24 +128,24 @@ class LAB_Oscilloscope : public LAB_Module
 
      uint32_t
     conv_raw_osc_samp_to_recon_chan_adc_data    (uint32_t raw_osc_samp,       unsigned channel);
-    
+
     void                reset_dma_process                               ();
     void                reset_uncached_rx_buffer                        ();
     void                record_raw_sample_buffer_metadata               ();
 
-  public:   
+  public:
     LAB_Oscilloscope (LAB& _LAB);
-   ~LAB_Oscilloscope ();   
+   ~LAB_Oscilloscope ();
 
     // master controls
     void                  run                     ();
-    void                  stop                    ();  
+    void                  stop                    ();
     void                  frontend_run_stop       (bool value);
     void                  backend_run_stop        (bool value);
     void                  single                  ();
     void                  do_measurements         (bool value);
 
-    // mode 
+    // mode
     void                  mode                    (LABE::OSC::MODE mode);
     LABE::OSC::MODE       mode                    ();
 
@@ -171,8 +171,8 @@ class LAB_Oscilloscope : public LAB_Module
     void                  sampling_rate           (double value);
     double                sampling_rate           () const;
     unsigned              samples_displayed       () const;
-    
-    // trigger 
+
+    // trigger
     void                  trigger_mode            (LABE::OSC::TRIG::MODE value);
     LABE::OSC::TRIG::MODE trigger_mode            () const;
     void                  trigger_source          (unsigned chan);
@@ -199,9 +199,9 @@ class LAB_Oscilloscope : public LAB_Module
     LABE::OSC::STATUS     status                  () const;
 
     // for display update
-    void                  update_data_samples       (); 
+    void                  update_data_samples       ();
 
-    
+
     // Data
     const LAB_Parent_Data_Oscilloscope&                     parent_data     ();
 
@@ -214,8 +214,10 @@ class LAB_Oscilloscope : public LAB_Module
     double raw_buffer_time_per_division () const;
     double raw_buffer_horizontal_offset () const;
     double raw_buffer_sampling_rate     () const;
-    
+
     const std::array<double, LABC::OSC::NUMBER_OF_SAMPLES>& chan_samples (unsigned channel) const;
+
+    void                  sync_display_metadata_from_current_settings ();
 
   public:
     Measurements& measurements  ();

--- a/src/LABSoft_Presenter/LABSoft_Presenter_Oscilloscope.cpp
+++ b/src/LABSoft_Presenter/LABSoft_Presenter_Oscilloscope.cpp
@@ -15,7 +15,7 @@ LABSoft_Presenter_Oscilloscope (LABSoft_Presenter& _LABSoft_Presenter)
   init_gui_values ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 init_gui_values () const
 {
   LAB_Oscilloscope& osc = lab ().m_Oscilloscope;
@@ -23,21 +23,21 @@ init_gui_values () const
   // ========== 1. vertical ==========
 
   // 1.1. channel enable disable
-  osc.is_channel_enabled (0) ? 
+  osc.is_channel_enabled (0) ?
     gui ().oscilloscope_fl_light_button_channel_0_enable->set    ():
     gui ().oscilloscope_fl_light_button_channel_0_enable->clear  ();
-  
-  osc.is_channel_enabled (1) ? 
+
+  osc.is_channel_enabled (1) ?
     gui ().oscilloscope_fl_light_button_channel_1_enable->set    ():
     gui ().oscilloscope_fl_light_button_channel_1_enable->clear  ();
 
   // 1.2. coupling
-  osc.coupling (0) == LABE::OSC::COUPLING::AC ? 
-    gui ().oscilloscope_fl_light_button_channel_0_ac_coupling->set   (): 
+  osc.coupling (0) == LABE::OSC::COUPLING::AC ?
+    gui ().oscilloscope_fl_light_button_channel_0_ac_coupling->set   ():
     gui ().oscilloscope_fl_light_button_channel_0_ac_coupling->clear ();
 
-  osc.coupling (1) == LABE::OSC::COUPLING::AC ? 
-    gui ().oscilloscope_fl_light_button_channel_1_ac_coupling->set   (): 
+  osc.coupling (1) == LABE::OSC::COUPLING::AC ?
+    gui ().oscilloscope_fl_light_button_channel_1_ac_coupling->set   ():
     gui ().oscilloscope_fl_light_button_channel_1_ac_coupling->clear ();
 
   // 1.3. scaling
@@ -52,10 +52,10 @@ init_gui_values () const
     LABSoft_GUI_Fl_Choice_With_Scroll* w;
 
     w = gui ().oscilloscope_labsoft_gui_fl_choice_with_scroll_channel_1_scaling;
-  
+
     w->value (w->find_index (LABS_GUI_VALUES::OSC::SCALING_s.at (osc.scaling (1)).c_str ()));
-  } 
-  
+  }
+
   // 1.4. voltage per division
   {
     LABSoft_GUI_Fl_Input_Choice_With_Scroll* w;
@@ -67,13 +67,13 @@ init_gui_values () const
   }
   {
     LABSoft_GUI_Fl_Input_Choice_With_Scroll* w;
-    
+
     w = gui ().oscilloscope_labsoft_gui_fl_input_choice_with_scroll_channel_1_voltage_per_division;
 
     w->value (LABSoft_GUI_Label (osc.voltage_per_division (1)).
       to_text (LABSoft_GUI_Label::UNIT::VOLT_PER_DIVISION).c_str ());
   }
-  
+
   // 1.5. vertical offset
   {
     LABSoft_GUI_Fl_Input_Choice_With_Scroll* w;
@@ -91,7 +91,7 @@ init_gui_values () const
     w->value (LABSoft_GUI_Label (osc.vertical_offset (1)).
       to_text (LABSoft_GUI_Label::UNIT::VOLT).c_str ());
   }
-  
+
   // ========== 2. horizontal ==========
   update_gui_horizontal_elements ();
 
@@ -111,7 +111,7 @@ init_gui_values () const
 
     w->value (w->find_index (LABS_GUI_VALUES::OSC::TRIGGER_SOURCE_s.at
       (osc.trigger_source ()).c_str ()));
-  } 
+  }
   {
     LABSoft_GUI_Fl_Choice_With_Scroll* w;
 
@@ -140,17 +140,17 @@ init_gui_values () const
 
     w = gui ().oscilloscope_labsoft_gui_fl_choice_with_scroll_mode;
 
-    w->value (w->find_index (LABS_GUI_VALUES::OSC::MODE_s.at 
-      (osc.mode ()).c_str ())); 
+    w->value (w->find_index (LABS_GUI_VALUES::OSC::MODE_s.at
+      (osc.mode ()).c_str ()));
   }
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_panel_vertical_offset (unsigned channel) const
 {
   LABSoft_GUI_Label label (
     lab ().m_Oscilloscope.vertical_offset (channel),
-    LABSoft_GUI_Label::UNIT::VOLT 
+    LABSoft_GUI_Label::UNIT::VOLT
   );
 
   if (channel)
@@ -158,14 +158,14 @@ update_gui_panel_vertical_offset (unsigned channel) const
     gui ().oscilloscope_labsoft_gui_fl_input_choice_with_scroll_channel_1_vertical_offset->
       value (label.to_text ().c_str ());
   }
-  else 
+  else
   {
     gui ().oscilloscope_labsoft_gui_fl_input_choice_with_scroll_channel_0_vertical_offset->
       value (label.to_text ().c_str ());
-  }  
+  }
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_panel_voltage_per_division (unsigned channel) const
 {
   LABSoft_GUI_Label label (
@@ -178,11 +178,11 @@ update_gui_panel_voltage_per_division (unsigned channel) const
     gui ().oscilloscope_labsoft_gui_fl_input_choice_with_scroll_channel_1_voltage_per_division->
       value (label.to_text ().c_str ());
   }
-  else 
+  else
   {
     gui ().oscilloscope_labsoft_gui_fl_input_choice_with_scroll_channel_0_voltage_per_division->
       value (label.to_text ().c_str ());
-  } 
+  }
 }
 
 void LABSoft_Presenter_Oscilloscope::
@@ -197,43 +197,43 @@ update_gui_panel_horizontal_offset () const
     value (label.to_text ().c_str ());
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_panel_time_per_division () const
 {
   LABSoft_GUI_Label label (
     lab ().m_Oscilloscope.time_per_division (),
     LABSoft_GUI_Label::UNIT::SECOND_PER_DIVISION
   );
-  
+
   gui ().oscilloscope_labsoft_gui_fl_input_choice_with_scroll_time_per_division->
     value (label.to_text ().c_str ());
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_panel_samples () const
 {
   LABSoft_GUI_Label label (
     lab ().m_Oscilloscope.samples (),
     LABSoft_GUI_Label::UNIT::NONE
   );
-  
+
   gui ().oscilloscope_labsoft_gui_fl_input_choice_with_scroll_samples->
     value (label.to_text ().c_str ());
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_panel_sampling_rate () const
 {
   LABSoft_GUI_Label label (
     lab ().m_Oscilloscope.sampling_rate (),
     LABSoft_GUI_Label::UNIT::HERTZ
   );
-  
+
   gui ().oscilloscope_labsoft_gui_fl_input_choice_with_scroll_sampling_rate->
     value (label.to_text ().c_str ());
 }
-  
-void LABSoft_Presenter_Oscilloscope:: 
+
+void LABSoft_Presenter_Oscilloscope::
 update_gui_panel_mode () const
 {
   LABE::OSC::MODE mode = lab ().m_Oscilloscope.mode ();
@@ -247,7 +247,7 @@ update_gui_panel_mode () const
     gui ().oscilloscope_fl_button_record->show          ();
     gui ().oscilloscope_fl_button_record_config->show   ();
   }
-  else 
+  else
   {
     gui ().oscilloscope_fl_light_button_run_stop->show  ();
     gui ().oscilloscope_fl_button_single->show          ();
@@ -257,13 +257,13 @@ update_gui_panel_mode () const
   }
 
   // 2.
-  LABSoft_GUI_Fl_Choice_With_Scroll& w = 
+  LABSoft_GUI_Fl_Choice_With_Scroll& w =
     *(gui ().oscilloscope_labsoft_gui_fl_choice_with_scroll_mode);
-  
+
   w.value (w.find_index (LABS_GUI_VALUES::OSC::MODE_s.at (mode).c_str ()));
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_panel_trigger_level () const
 {
   LABSoft_GUI_Label label (
@@ -275,7 +275,7 @@ update_gui_panel_trigger_level () const
     value (label.to_text ().c_str ());
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_vertical_offset (unsigned channel) const
 {
   update_gui_panel_vertical_offset (channel);
@@ -286,9 +286,9 @@ update_gui_vertical_offset (unsigned channel) const
   lab ().m_Oscilloscope_Display.update_cached_values ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_voltage_per_division (unsigned channel) const
-{ 
+{
   update_gui_panel_voltage_per_division (channel);
 
   gui ().oscilloscope_labsoft_gui_oscilloscope_display->
@@ -297,33 +297,33 @@ update_gui_voltage_per_division (unsigned channel) const
   lab ().m_Oscilloscope_Display.update_cached_values ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_horizontal_offset () const
 {
   update_gui_panel_horizontal_offset ();
 
   gui ().oscilloscope_labsoft_gui_oscilloscope_display->
-    horizontal_offset (lab ().m_Oscilloscope.horizontal_offset ());  
+    horizontal_offset (lab ().m_Oscilloscope.horizontal_offset ());
 
   lab ().m_Oscilloscope_Display.update_cached_values ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
-update_gui_time_per_division () 
+void LABSoft_Presenter_Oscilloscope::
+update_gui_time_per_division ()
 {
-  update_gui_horizontal_elements ();  
+  update_gui_horizontal_elements ();
 
   gui ().oscilloscope_labsoft_gui_oscilloscope_display->
-    time_per_division (lab ().m_Oscilloscope.time_per_division ());  
+    time_per_division (lab ().m_Oscilloscope.time_per_division ());
 
-  lab ().m_Oscilloscope_Display.update_cached_values (); 
-  
+  lab ().m_Oscilloscope_Display.update_cached_values ();
+
   gui ().oscilloscope_labsoft_gui_oscilloscope_display->
     mark_samples (lab ().m_Oscilloscope_Display.mark_samples ());
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
-update_gui_samples () 
+void LABSoft_Presenter_Oscilloscope::
+update_gui_samples ()
 {
   update_gui_horizontal_elements ();
 
@@ -333,8 +333,8 @@ update_gui_samples ()
     mark_samples (lab ().m_Oscilloscope_Display.mark_samples ());
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
-update_gui_sampling_rate () 
+void LABSoft_Presenter_Oscilloscope::
+update_gui_sampling_rate ()
 {
   update_gui_horizontal_elements ();
 
@@ -344,7 +344,7 @@ update_gui_sampling_rate ()
     mark_samples (lab ().m_Oscilloscope_Display.mark_samples ());
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_horizontal_elements () const
 {
   update_gui_panel_horizontal_offset  ();
@@ -354,13 +354,13 @@ update_gui_horizontal_elements () const
   update_gui_panel_mode               ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_mode () const
 {
   update_gui_panel_mode ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_trigger_level () const
 {
   update_gui_panel_trigger_level ();
@@ -369,7 +369,7 @@ update_gui_trigger_level () const
     trigger_level (lab ().m_Oscilloscope.trigger_level ());
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 update_gui_trigger_panel () const
 {
   if (lab ().m_Oscilloscope.trigger_mode () == LABE::OSC::TRIG::MODE::NONE)
@@ -379,7 +379,7 @@ update_gui_trigger_panel () const
     gui ().oscilloscope_fl_choice_trigger_condition->deactivate ();
     gui ().oscilloscope_labsoft_gui_fl_input_choice_with_scroll_trigger_level->deactivate ();
   }
-  else 
+  else
   {
     gui ().oscilloscope_fl_choice_trigger_source->activate ();
     gui ().oscilloscope_fl_choice_trigger_type->activate ();
@@ -388,12 +388,21 @@ update_gui_trigger_panel () const
   }
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
-cb_run_stop (Fl_Light_Button* w, 
+void LABSoft_Presenter_Oscilloscope::
+cb_run_stop (Fl_Light_Button* w,
              void*            data)
 {
   if (w->value ())
   {
+    if (presenter().lab().m_Analog_Circuit_Checker.is_file_loaded())
+    {
+      if (gui().function_generator_fl_light_button_run_stop)
+      {
+        gui().function_generator_fl_light_button_run_stop->value(0);
+        presenter().m_Function_Generator.cb_run_stop(gui().function_generator_fl_light_button_run_stop, 0);
+      }
+    }
+
     presenter ().m_Oscilloscope.stop_gui ();
     presenter ().m_Voltmeter   .stop_gui ();
     presenter ().m_Ohmmeter    .stop_gui ();
@@ -404,7 +413,7 @@ cb_run_stop (Fl_Light_Button* w,
 
     presenter ().m_Oscilloscope.run_gui ();
   }
-  else 
+  else
   {
     lab ().m_Oscilloscope.stop ();
 
@@ -412,7 +421,7 @@ cb_run_stop (Fl_Light_Button* w,
   }
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 run_gui ()
 {
   lab ().m_Oscilloscope_Display.update_cached_values ();
@@ -429,7 +438,7 @@ stop_gui ()
   gui ().oscilloscope_fl_light_button_run_stop->clear ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_single (Fl_Button* w,
            void*      data)
 {
@@ -438,7 +447,7 @@ cb_single (Fl_Button* w,
   lab ().m_Oscilloscope.single ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_channel_enable_disable (Fl_Light_Button* w,
                            long             channel)
 {
@@ -448,7 +457,7 @@ cb_channel_enable_disable (Fl_Light_Button* w,
 }
 
 void LABSoft_Presenter_Oscilloscope::
-cb_ac_coupling (Fl_Light_Button*  w, 
+cb_ac_coupling (Fl_Light_Button*  w,
                 long              channel)
 {
   lab ().m_Oscilloscope.coupling (
@@ -457,7 +466,7 @@ cb_ac_coupling (Fl_Light_Button*  w,
   );
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_scaling (LABSoft_GUI_Fl_Choice_With_Scroll*  w,
             long                                channel)
 {
@@ -468,9 +477,9 @@ cb_scaling (LABSoft_GUI_Fl_Choice_With_Scroll*  w,
 }
 
 void LABSoft_Presenter_Oscilloscope::
-cb_vertical_offset (LABSoft_GUI_Fl_Input_Choice_With_Scroll*  w, 
+cb_vertical_offset (LABSoft_GUI_Fl_Input_Choice_With_Scroll*  w,
                     long                                      channel)
-{ 
+{
   LABSoft_GUI_Label label (
     w->value (),
     lab ().m_Oscilloscope.vertical_offset (channel),
@@ -486,7 +495,7 @@ cb_vertical_offset (LABSoft_GUI_Fl_Input_Choice_With_Scroll*  w,
 }
 
 void LABSoft_Presenter_Oscilloscope::
-cb_voltage_per_division (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w, 
+cb_voltage_per_division (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w,
                         long                                      channel)
 {
   LABSoft_GUI_Label label (
@@ -503,7 +512,7 @@ cb_voltage_per_division (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w,
   update_gui_voltage_per_division (channel);
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_vertical_offset_slider (LABSoft_GUI_Fl_Slider* w,
                            void*                  data)
 {
@@ -512,7 +521,7 @@ cb_vertical_offset_slider (LABSoft_GUI_Fl_Slider* w,
 
 // horizontal
 void LABSoft_Presenter_Oscilloscope::
-cb_horizontal_offset (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w, 
+cb_horizontal_offset (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w,
                       void*                                    data) const
 {
   LABSoft_GUI_Label label (
@@ -529,7 +538,7 @@ cb_horizontal_offset (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w,
   update_gui_horizontal_offset ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_time_per_division (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w,
                       void*                                    data)
 {
@@ -543,16 +552,16 @@ cb_time_per_division (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w,
   {
     lab ().m_Oscilloscope.time_per_division (label.actual_value ());
   }
-  
+
   update_gui_time_per_division ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_samples (Fl_Input_Choice*  w,
             void*             data)
 {
   LABSoft_GUI_Label label (
-    w->value (), 
+    w->value (),
     0, // 0 as reference kay whole numbers raman sad ang samples
     LABSoft_GUI_Label::UNIT::NONE
   );
@@ -565,7 +574,7 @@ cb_samples (Fl_Input_Choice*  w,
   update_gui_samples ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_sampling_rate (Fl_Input_Choice*  w,
                   void*             data)
 {
@@ -574,7 +583,7 @@ cb_sampling_rate (Fl_Input_Choice*  w,
     lab ().m_Oscilloscope.sampling_rate (),
     LABSoft_GUI_Label::UNIT::HERTZ
   );
-  
+
   if (label.is_valid ())
   {
     lab ().m_Oscilloscope.sampling_rate (label.actual_value ());
@@ -584,7 +593,7 @@ cb_sampling_rate (Fl_Input_Choice*  w,
 }
 
 void LABSoft_Presenter_Oscilloscope::
-cb_mode (Fl_Choice* w,  
+cb_mode (Fl_Choice* w,
          void*      data)
 {
   std::string str (w->text ());
@@ -603,7 +612,7 @@ cb_mode (Fl_Choice* w,
   {
     mode = LABE::OSC::MODE::RECORD;
   }
-  else 
+  else
   {
     throw (std::runtime_error ("Invalid display mode input."));
   }
@@ -627,7 +636,7 @@ cb_trigger_mode (Fl_Choice* w,
 }
 
 void LABSoft_Presenter_Oscilloscope::
-cb_trigger_source (Fl_Choice* w, 
+cb_trigger_source (Fl_Choice* w,
                    void*      data)
 {
   unsigned trigger_source = LABS_GUI_VALUES::OSC::TRIGGER_SOURCE.at (std::string (w->text ()));
@@ -637,7 +646,7 @@ cb_trigger_source (Fl_Choice* w,
   gui ().oscilloscope_labsoft_gui_oscilloscope_display->trigger_source (trigger_source);
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_trigger_type (Fl_Choice* w,
                  void*      data)
 {
@@ -652,15 +661,15 @@ cb_trigger_type (Fl_Choice* w,
   {
     type = LABE::OSC::TRIG::TYPE::LEVEL;
   }
-  else 
+  else
   {
     throw (std::runtime_error ("Invalid trigger type input."));
   }
-  
+
   lab ().m_Oscilloscope.trigger_type (type);
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_trigger_condition (Fl_Choice* w,
                       void*      data)
 {
@@ -679,7 +688,7 @@ cb_trigger_condition (Fl_Choice* w,
   {
     cnd = LABE::OSC::TRIG::CND::EITHER;
   }
-  else 
+  else
   {
     throw (std::runtime_error ("Invalid trigger condition input."));
   }
@@ -688,7 +697,7 @@ cb_trigger_condition (Fl_Choice* w,
 }
 
 void LABSoft_Presenter_Oscilloscope::
-cb_trigger_level (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w, 
+cb_trigger_level (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w,
                   void*            data)
 {
   LABSoft_GUI_Label label (
@@ -705,8 +714,8 @@ cb_trigger_level (LABSoft_GUI_Fl_Input_Choice_With_Scroll* w,
   update_gui_trigger_level ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
-cb_trigger_level_slider (LABSoft_GUI_Fl_Slider* w, 
+void LABSoft_Presenter_Oscilloscope::
+cb_trigger_level_slider (LABSoft_GUI_Fl_Slider* w,
                          void*                  data)
 {
   lab ().m_Oscilloscope.trigger_level (w->value ());
@@ -719,14 +728,14 @@ cb_trigger_level_slider (LABSoft_GUI_Fl_Slider* w,
 }
 
 void LABSoft_Presenter_Oscilloscope::
-cb_record (Fl_Button*  w, 
+cb_record (Fl_Button*  w,
            void*       data)
 {
 
 }
 
 void LABSoft_Presenter_Oscilloscope::
-cb_record_config (Fl_Button* w, 
+cb_record_config (Fl_Button* w,
                   void*      data)
 {
   gui ().oscilloscope_fl_window_record_config->show ();
@@ -748,16 +757,16 @@ cb_record_config_cancel (Fl_Button* w,
   gui ().main_fl_tabs->activate ();
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_export (Fl_Menu_Item*  w,
            void*          data)
 {
 
 }
-    
-void LABSoft_Presenter_Oscilloscope:: 
+
+void LABSoft_Presenter_Oscilloscope::
 display_update_cycle ()
-{ 
+{
   if (lab ().m_Oscilloscope.is_backend_running ())
   {
     lab ().m_Oscilloscope.update_data_samples ();
@@ -774,7 +783,7 @@ display_update_cycle ()
   }
 }
 
-void LABSoft_Presenter_Oscilloscope:: 
+void LABSoft_Presenter_Oscilloscope::
 cb_debug_measurements (Fl_Light_Button* w, void* data)
 {
   lab ().m_Oscilloscope.do_measurements (w->value ());

--- a/src/LABSoft_Presenter/Software/LABSoft_Presenter_Analog_Circuit_Checker.cpp
+++ b/src/LABSoft_Presenter/Software/LABSoft_Presenter_Analog_Circuit_Checker.cpp
@@ -623,6 +623,41 @@ update_gui_oscilloscope()
     gui.oscilloscope_labsoft_gui_fl_input_choice_with_scroll_trigger_level->activate();
     set_input_choice_to_value(gui.oscilloscope_labsoft_gui_fl_input_choice_with_scroll_trigger_level, UnitKind::VOLT, m_metadata.trigger_level);
   }
+
+  // Sync Oscilloscope tab display with imported settings (apply to display widget and refresh caches)
+  if (gui.oscilloscope_labsoft_gui_oscilloscope_display)
+  {
+    // Channel enable/disable and vertical params
+    bool ch0_en = (m_metadata.channels.size() >= 1) ? m_metadata.channels[0].is_enabled : false;
+    bool ch1_en = (m_metadata.channels.size() >= 2) ? m_metadata.channels[1].is_enabled : false;
+
+    gui.oscilloscope_labsoft_gui_oscilloscope_display->channel_enable_disable(0, ch0_en);
+    gui.oscilloscope_labsoft_gui_oscilloscope_display->channel_enable_disable(1, ch1_en);
+
+    if (m_metadata.channels.size() >= 1)
+    {
+      const auto &ch0 = m_metadata.channels[0];
+      gui.oscilloscope_labsoft_gui_oscilloscope_display->voltage_per_division(0, ch0.voltage_per_div);
+      gui.oscilloscope_labsoft_gui_oscilloscope_display->vertical_offset(0, ch0.vertical_offset);
+    }
+    if (m_metadata.channels.size() >= 2)
+    {
+      const auto &ch1 = m_metadata.channels[1];
+      gui.oscilloscope_labsoft_gui_oscilloscope_display->voltage_per_division(1, ch1.voltage_per_div);
+      gui.oscilloscope_labsoft_gui_oscilloscope_display->vertical_offset(1, ch1.vertical_offset);
+    }
+
+    // Horizontal/global and trigger
+    gui.oscilloscope_labsoft_gui_oscilloscope_display->horizontal_offset(m_metadata.horizontal_offset);
+    gui.oscilloscope_labsoft_gui_oscilloscope_display->time_per_division(m_metadata.time_per_division);
+    gui.oscilloscope_labsoft_gui_oscilloscope_display->samples(m_metadata.samples);
+    gui.oscilloscope_labsoft_gui_oscilloscope_display->sampling_rate(m_metadata.sampling_rate);
+    gui.oscilloscope_labsoft_gui_oscilloscope_display->trigger_source(m_metadata.trigger_source);
+    gui.oscilloscope_labsoft_gui_oscilloscope_display->trigger_level(m_metadata.trigger_level);
+  }
+
+  lab().m_Oscilloscope_Display.update_cached_values();
+  presenter().m_Oscilloscope_Display.update_display();
 }
 
 void LABSoft_Presenter_Analog_Circuit_Checker::
@@ -630,18 +665,18 @@ update_gui_function_generator()
 {
   LABSoft_GUI& gui = m_presenter.gui();
 
-  if (gui.function_generator_fl_input_choice_frequency)
+  // Apply imported settings to the actual Function Generator model (channel 0)
   {
-    set_input_choice_to_value(gui.function_generator_fl_input_choice_frequency,
-                              UnitKind::HERTZ,
-                              m_metadata.function_generator.frequency);
-  }
-
-  if (gui.function_generator_fl_input_choice_period)
-  {
-    set_input_choice_to_value(gui.function_generator_fl_input_choice_period,
-                              UnitKind::SECOND,
-                              m_metadata.function_generator.period);
+    LAB_Function_Generator &gen = lab().m_Function_Generator;
+    // Wave type
+    gen.wave_type(0, static_cast<LABE::FUNC_GEN::WAVE_TYPE>(m_metadata.function_generator.wave_type));
+    // Frequency/Period (set whichever are valid)
+    if (m_metadata.function_generator.frequency > 0.0)
+      gen.frequency(0, m_metadata.function_generator.frequency);
+    if (m_metadata.function_generator.period > 0.0)
+      gen.period(0, m_metadata.function_generator.period);
+    // Ensure GUI fields that mirror frequency/period stay consistent
+    m_presenter.m_Function_Generator.update_gui_frequency_elements();
   }
 
   if (gui.function_generator_fl_choice_wave_type)
@@ -759,7 +794,9 @@ cb_load_file_acc(Fl_Button* w, void* data)
           update_gui_acc_comparison         ();
           update_gui_analog_circuit_checker ();
 
-          // fl_message("File loaded successfully. Click 'Run Checker' to display data in oscilloscope.");
+          lab().m_Oscilloscope.sync_display_metadata_from_current_settings();
+          lab().m_Oscilloscope_Display.update_cached_values();
+          presenter().m_Oscilloscope_Display.update_display();
         }
         else
         {

--- a/src/LABSoft_Presenter/Software/LABSoft_Presenter_Analog_Circuit_Checker.cpp
+++ b/src/LABSoft_Presenter/Software/LABSoft_Presenter_Analog_Circuit_Checker.cpp
@@ -654,6 +654,18 @@ update_gui_function_generator()
 {
   LABSoft_GUI& gui = m_presenter.gui();
 
+  {
+    LAB_Function_Generator &gen = lab().m_Function_Generator;
+    gen.wave_type(0, static_cast<LABE::FUNC_GEN::WAVE_TYPE>(m_metadata.function_generator.wave_type));
+
+    if (m_metadata.function_generator.frequency > 0.0)
+      gen.frequency(0, m_metadata.function_generator.frequency);
+    if (m_metadata.function_generator.period > 0.0)
+      gen.period(0, m_metadata.function_generator.period);
+
+    m_presenter.m_Function_Generator.update_gui_frequency_elements();
+  }
+
   if (gui.function_generator_fl_input_choice_frequency && (m_metadata.function_generator.frequency > 0.0))
   {
     LABSoft_GUI_Label lbl(m_metadata.function_generator.frequency, LABSoft_GUI_Label::UNIT::HERTZ);

--- a/src/LABSoft_Presenter/Software/LABSoft_Presenter_Analog_Circuit_Checker.cpp
+++ b/src/LABSoft_Presenter/Software/LABSoft_Presenter_Analog_Circuit_Checker.cpp
@@ -20,6 +20,7 @@
 #include "../../LABSoft_GUI/LABSoft_GUI.h"
 #include "../../LABSoft_GUI/LABSoft_GUI_Analog_Circuit_Checker_Display.h"
 #include "../../Utility/LAB_Utility_Functions.h"
+#include "../../Utility/LABSoft_GUI_Label.h"
 
 enum class UnitKind { VOLT, SECOND, HERTZ, SAMPLES };
 
@@ -653,18 +654,16 @@ update_gui_function_generator()
 {
   LABSoft_GUI& gui = m_presenter.gui();
 
-  // Apply imported settings to the actual Function Generator model (channel 0)
+  if (gui.function_generator_fl_input_choice_frequency && (m_metadata.function_generator.frequency > 0.0))
   {
-    LAB_Function_Generator &gen = lab().m_Function_Generator;
-    // Wave type
-    gen.wave_type(0, static_cast<LABE::FUNC_GEN::WAVE_TYPE>(m_metadata.function_generator.wave_type));
-    // Frequency/Period (set whichever are valid)
-    if (m_metadata.function_generator.frequency > 0.0)
-      gen.frequency(0, m_metadata.function_generator.frequency);
-    if (m_metadata.function_generator.period > 0.0)
-      gen.period(0, m_metadata.function_generator.period);
-    // Ensure GUI fields that mirror frequency/period stay consistent
-    m_presenter.m_Function_Generator.update_gui_frequency_elements();
+    LABSoft_GUI_Label lbl(m_metadata.function_generator.frequency, LABSoft_GUI_Label::UNIT::HERTZ);
+    gui.function_generator_fl_input_choice_frequency->value(lbl.to_text().c_str());
+  }
+
+  if (gui.function_generator_fl_input_choice_period && (m_metadata.function_generator.period > 0.0))
+  {
+    LABSoft_GUI_Label lbl(m_metadata.function_generator.period, LABSoft_GUI_Label::UNIT::SECOND);
+    gui.function_generator_fl_input_choice_period->value(lbl.to_text().c_str());
   }
 
   if (gui.function_generator_fl_choice_wave_type)

--- a/src/LABSoft_Presenter/Software/LABSoft_Presenter_Analog_Circuit_Checker.cpp
+++ b/src/LABSoft_Presenter/Software/LABSoft_Presenter_Analog_Circuit_Checker.cpp
@@ -296,42 +296,30 @@ prepare_student_data()
   auto *acc_disp_ptr = gui_ptr ? gui_ptr->analog_circuit_checker_labsoft_gui_analog_circuit_checker_display : nullptr;
   if (acc_disp_ptr)
   {
-    LAB_Oscilloscope_Display &osc_disp = lab().m_Oscilloscope_Display;
+    const unsigned display_width  = acc_disp_ptr->display_width();
+    const unsigned display_height = acc_disp_ptr->display_height();
 
-    const unsigned analog_w = acc_disp_ptr->display_width();
-    const unsigned analog_h = acc_disp_ptr->display_height();
+    const size_t N = time_student.size();
+    time_student_pixels.reserve(N);
 
-    LABSoft_GUI_Oscilloscope_Display &osc_gui_disp = *(gui_ptr->oscilloscope_labsoft_gui_oscilloscope_display);
-    const unsigned osc_tab_w = osc_gui_disp.display_width();
-    const unsigned osc_tab_h = osc_gui_disp.display_height();
+    const double voltage_per_division = std::max(1e-9, osc.voltage_per_division(1));
+    const double voltage_range        = voltage_per_division * static_cast<double>(LABC::OSC_DISPLAY::NUMBER_OF_ROWS);
+    const double vertical_offset      = osc.vertical_offset(1);
 
-    const bool same_size = (analog_w == osc_tab_w) && (analog_h == osc_tab_h);
-    if (!same_size)
+    for (size_t i = 0; i < N; ++i)
     {
-      osc_disp.display_parameters(
-        analog_w,
-        analog_h,
-        LABC::OSC_DISPLAY::NUMBER_OF_ROWS,
-        LABC::OSC_DISPLAY::NUMBER_OF_COLUMNS
-      );
-    }
+      const size_t denom = (N > 1) ? (N - 1) : 1;
+      int x = static_cast<int>((static_cast<double>(i) * static_cast<double>(display_width - 1)) / static_cast<double>(denom));
 
-    osc_disp.update_pixel_points();
-    const auto &raw_buf = osc_disp.pixel_points();
+      const double corrected_voltage = time_student[i] + vertical_offset;
+      double normalized_voltage = (corrected_voltage + (voltage_range / 2.0)) / voltage_range;
+      normalized_voltage = clamp01(normalized_voltage);
+      int y = static_cast<int>(display_height * (1.0 - normalized_voltage));
 
-    time_student_pixels.clear();
-    if (raw_buf.size() > 1)
-      time_student_pixels = raw_buf[1];
+      x = std::max(0, std::min(x, static_cast<int>(display_width - 1)));
+      y = std::max(0, std::min(y, static_cast<int>(display_height - 1)));
 
-    if (!same_size)
-    {
-      osc_disp.display_parameters(
-        osc_tab_w,
-        osc_tab_h,
-        LABC::OSC_DISPLAY::NUMBER_OF_ROWS,
-        LABC::OSC_DISPLAY::NUMBER_OF_COLUMNS
-      );
-      osc_disp.update_pixel_points();
+      time_student_pixels.push_back({x, y});
     }
   }
 }

--- a/src/LABSoft_Presenter/Software/LABSoft_Presenter_LABChecker_Analog.cpp
+++ b/src/LABSoft_Presenter/Software/LABSoft_Presenter_LABChecker_Analog.cpp
@@ -7,6 +7,7 @@
 #include "../../LAB/LAB.h"
 #include "../../LAB/LAB_Oscilloscope.h"
 #include "../../LAB/LAB_Function_Generator.h"
+#include "../../Utility/LABSoft_GUI_Label.h"
 #include "../../Utility/LABSoft_GUI_Label_Values.h"
 #include "../LABSoft_Presenter.h"
 #include "../../LABSoft_GUI/LABSoft_GUI.h"
@@ -253,6 +254,44 @@ cb_analog_create_file(Fl_Button *w, void *data)
   fg_data.amplitude = fg.amplitude(0);
   fg_data.vertical_offset = fg.vertical_offset(0);
   fg_data.phase = fg.phase(0);
+
+  // Prefer exact values typed in the Function Generator tab over any display/menu rounding
+  if (acc->gui().function_generator_fl_input_choice_frequency)
+  {
+    LABSoft_GUI_Label lbl(
+      acc->gui().function_generator_fl_input_choice_frequency->value(),
+      fg_data.frequency,
+      LABSoft_GUI_Label::UNIT::HERTZ
+    );
+
+    if (lbl.is_valid())
+    {
+      double f = lbl.actual_value();
+      if (f > 0.0)
+      {
+        fg_data.frequency = f;
+        fg_data.period = 1.0 / f;
+      }
+    }
+  }
+  else if (acc->gui().function_generator_fl_input_choice_period)
+  {
+    LABSoft_GUI_Label lbl(
+      acc->gui().function_generator_fl_input_choice_period->value(),
+      fg_data.period,
+      LABSoft_GUI_Label::UNIT::SECOND
+    );
+
+    if (lbl.is_valid())
+    {
+      double p = lbl.actual_value();
+      if (p > 0.0)
+      {
+        fg_data.period = p;
+        fg_data.frequency = 1.0 / p;
+      }
+    }
+  }
 
   // Save dialog
   Fl_Native_File_Chooser chooser;


### PR DESCRIPTION
- Synchronized oscilloscope and function generator settings with imported metadata.
- Prevented imported signals from being cached in the oscilloscope tab display.
- Ensured the function generator starts automatically when importing files in the ACC tab.
- Fixed unintended function generator auto-run when the oscilloscope starts.